### PR TITLE
Fixed wrong assumption that zero-length Protobuf is invalid

### DIFF
--- a/UnityProject/Assets/LoomSDK/Source/Runtime/Contract.cs
+++ b/UnityProject/Assets/LoomSDK/Source/Runtime/Contract.cs
@@ -102,7 +102,7 @@ namespace Loom.Client
             {
                 var resp = new Response();
                 resp.MergeFrom(result.DeliverTx.Data);
-                if (resp.Body != null && resp.Body.Length != 0)
+                if (resp.Body != null)
                 {
                     T msg = new T();
                     msg.MergeFrom(resp.Body);


### PR DESCRIPTION
Funnily enough, if all fields of a message are set to their default values, Protobuf will serialize the message into nothing, 0 bytes. That is actually a valid situation and shouldn't be ignored.
I was getting mysterious `NullReferenceException` when deserializing this message with `deck_id` set to 0.
```
message CreateDeckResponse {
    int64 deck_id = 1;
}
```
Well, not anymore.